### PR TITLE
Updates 2021 07 14

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,18 @@
+<Project>
+  <!-- Leave this file here, even if it's empty. It stops chaining imports. -->
+
+  <!-- In Directory.Build.targets because default items are added after Directory.Build.props is imported, causing invalid duplicate entries. -->
+  <ItemGroup Condition="Exists( '$(MSBuildProjectDirectory)\Properties\Resources.resx' )">
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Deterministic>true</Deterministic>
     <Company>Tingle Software Limited</Company>
+    <!--<IsPackable>true</IsPackable>-->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,33 @@
+<Project>
+  <!-- Chain up to the next file (can be copy-pasted to either Directory.Build.props or Directory.Build.targets) -->
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., '$(MSBuildThisFileName)$(MSBuildThisFileExtension)'))\$(MSBuildThisFileName)$(MSBuildThisFileExtension)" />
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Deterministic>true</Deterministic>
+    <Company>Tingle Software Limited</Company>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!--  Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+    <!-- Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <VersionPrefix Condition="'$(GITVERSION_NUGETVERSION)' != ''">$(GITVERSION_NUGETVERSION)</VersionPrefix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/src/Falu/Core/BasicListOptions.cs
+++ b/src/Falu/Core/BasicListOptions.cs
@@ -58,19 +58,7 @@ namespace Falu.Core
         internal static string ConvertDate(DateTimeOffset d) => d.ToString("o");
         internal static string ConvertInt32(int i) => i.ToString();
         internal static string ConvertInt64(long i) => i.ToString();
-        internal static string ConvertEnum<T>(T e) where T : Enum
-        {
-            // Give priority to EnumMemberAttribute
-            var memInfo = typeof(T).GetMember(e.ToString());
-            var attr = memInfo.FirstOrDefault()?.GetCustomAttributes(false)
-                              .OfType<EnumMemberAttribute>()
-                              .FirstOrDefault();
-
-            return attr?.Value ?? e.ToString().ToLowerInvariant();
-        }
-        internal static string ConvertEnumList<T>(IList<T> list) where T : Enum
-        {
-            return string.Join(",", list.Select(l => ConvertEnum(l)));
-        }
+        internal static string ConvertEnum<T>(T e) where T : Enum => e.GetEnumMemberAttrValueOrDefault();
+        internal static string ConvertEnumList<T>(IList<T> list) where T : Enum => string.Join(",", list.Select(l => ConvertEnum(l)));
     }
 }

--- a/src/Falu/Core/BasicListOptions.cs
+++ b/src/Falu/Core/BasicListOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 
 namespace Falu.Core
 {

--- a/src/Falu/Core/IHasTags.cs
+++ b/src/Falu/Core/IHasTags.cs
@@ -10,6 +10,7 @@ namespace Falu.Core
         /// <summary>
         /// Set of values that you can attach to an object. This can be useful for searching.
         /// </summary>
+        [System.Obsolete(MessageStrings.TagsDeprecated)]
         public List<string>? Tags { get; set; }
     }
 }

--- a/src/Falu/Evaluations/EvaluationPatchModel.cs
+++ b/src/Falu/Evaluations/EvaluationPatchModel.cs
@@ -15,6 +15,7 @@ namespace Falu.Evaluations
         public Dictionary<string, string>? Metadata { get; set; }
 
         /// <inheritdoc/>
+        [System.Obsolete(MessageStrings.TagsDeprecated)]
         public List<string>? Tags { get; set; }
     }
 }

--- a/src/Falu/Evaluations/EvaluationsService.cs
+++ b/src/Falu/Evaluations/EvaluationsService.cs
@@ -122,6 +122,7 @@ namespace Falu.Evaluations
             }
 
             // Add tags if provided
+#pragma warning disable CS0618 // Type or member is obsolete
             var tags = evaluation.Tags;
             if (tags != null)
             {
@@ -130,6 +131,7 @@ namespace Falu.Evaluations
                     content.Add(new StringContent(tags[i]), $"tags[{i}]");
                 }
             }
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // Add metadata if provided
             var metadata = evaluation.Metadata?.ToList();

--- a/src/Falu/Evaluations/EvaluationsService.cs
+++ b/src/Falu/Evaluations/EvaluationsService.cs
@@ -118,7 +118,7 @@ namespace Falu.Evaluations
             // Add description if provided
             if (!string.IsNullOrWhiteSpace(evaluation.Description))
             {
-                content.Add(new StringContent(evaluation.Description), nameof(evaluation.Description));
+                content.Add(new StringContent(evaluation.Description), "description");
             }
 
             // Add tags if provided
@@ -127,7 +127,7 @@ namespace Falu.Evaluations
             {
                 for (var i = 0; i < tags.Count; i++)
                 {
-                    content.Add(new StringContent(tags[i]), $"{nameof(evaluation.Tags)}[{i}]");
+                    content.Add(new StringContent(tags[i]), $"tags[{i}]");
                 }
             }
 
@@ -137,8 +137,8 @@ namespace Falu.Evaluations
             {
                 for (var i = 0; i < metadata.Count; i++)
                 {
-                    content.Add(new StringContent(metadata[i].Key), $"{nameof(evaluation.Metadata)}[{i}].Key");
-                    content.Add(new StringContent(metadata[i].Value), $"{nameof(evaluation.Metadata)}[{i}].Value");
+                    content.Add(new StringContent(metadata[i].Key), $"metadata[{i}].Key");
+                    content.Add(new StringContent(metadata[i].Value), $"metadata[{i}].Value");
                 }
             }
 

--- a/src/Falu/Evaluations/EvaluationsService.cs
+++ b/src/Falu/Evaluations/EvaluationsService.cs
@@ -84,13 +84,16 @@ namespace Falu.Evaluations
                                                                             CancellationToken cancellationToken = default)
         {
             if (evaluation is null) throw new ArgumentNullException(nameof(evaluation));
+            if (evaluation.Scope is null) throw new InvalidOperationException($"{nameof(evaluation.Scope)} cannot be null.");
+            if (evaluation.Provider is null) throw new InvalidOperationException($"{nameof(evaluation.Provider)} cannot be null.");
+            if (string.IsNullOrWhiteSpace(evaluation.Name)) throw new InvalidOperationException($"{nameof(evaluation.Name)} cannot be null or whitespace.");
 
             var content = new MultipartFormDataContent
             {
                 // populate fields of the model as key value pairs
                 { new StringContent(evaluation.Currency), "currency" },
-                { new StringContent(evaluation.Scope.ToString()), "scope" },
-                { new StringContent(evaluation.Provider.ToString()), "provider" },
+                { new StringContent(evaluation.Scope?.GetEnumMemberAttrValueOrDefault()), "scope" },
+                { new StringContent(evaluation.Provider?.GetEnumMemberAttrValueOrDefault()), "provider" },
                 { new StringContent(evaluation.Name), "name" },
                 { new StringContent(evaluation.Phone), "phone" },
                 { new StringContent(evaluation.Password), "password" },

--- a/src/Falu/Evaluations/EvaluationsService.cs
+++ b/src/Falu/Evaluations/EvaluationsService.cs
@@ -86,7 +86,10 @@ namespace Falu.Evaluations
             if (evaluation is null) throw new ArgumentNullException(nameof(evaluation));
             if (evaluation.Scope is null) throw new InvalidOperationException($"{nameof(evaluation.Scope)} cannot be null.");
             if (evaluation.Provider is null) throw new InvalidOperationException($"{nameof(evaluation.Provider)} cannot be null.");
-            if (string.IsNullOrWhiteSpace(evaluation.Name)) throw new InvalidOperationException($"{nameof(evaluation.Name)} cannot be null or whitespace.");
+            if (string.IsNullOrWhiteSpace(evaluation.Name))
+            {
+                throw new InvalidOperationException($"{nameof(evaluation.Name)} cannot be null or whitespace.");
+            }
 
             var content = new MultipartFormDataContent
             {
@@ -95,12 +98,22 @@ namespace Falu.Evaluations
                 { new StringContent(evaluation.Scope?.GetEnumMemberAttrValueOrDefault()), "scope" },
                 { new StringContent(evaluation.Provider?.GetEnumMemberAttrValueOrDefault()), "provider" },
                 { new StringContent(evaluation.Name), "name" },
-                { new StringContent(evaluation.Phone), "phone" },
-                { new StringContent(evaluation.Password), "password" },
 
                 // populate the file stream
                 { new StreamContent(evaluation.Content), "file", evaluation.FileName },
             };
+
+            // Add phone if provided
+            if (!string.IsNullOrWhiteSpace(evaluation.Phone))
+            {
+                content.Add(new StringContent(evaluation.Phone), "phone");
+            }
+
+            // Add password if provided
+            if (!string.IsNullOrWhiteSpace(evaluation.Password))
+            {
+                content.Add(new StringContent(evaluation.Password), "password");
+            }
 
             // Add description if provided
             if (!string.IsNullOrWhiteSpace(evaluation.Description))

--- a/src/Falu/Evaluations/EvaluationsService.cs
+++ b/src/Falu/Evaluations/EvaluationsService.cs
@@ -88,15 +88,15 @@ namespace Falu.Evaluations
             var content = new MultipartFormDataContent
             {
                 // populate fields of the model as key value pairs
-                { new StringContent(evaluation.Currency), nameof(evaluation.Currency) },
-                { new StringContent(evaluation.Scope.ToString()), nameof(evaluation.Scope) },
-                { new StringContent(evaluation.Provider.ToString()), nameof(evaluation.Provider) },
-                { new StringContent(evaluation.Name), nameof(evaluation.Name) },
-                { new StringContent(evaluation.Phone), nameof(evaluation.Phone) },
-                { new StringContent(evaluation.Password), nameof(evaluation.Password) },
+                { new StringContent(evaluation.Currency), "currency" },
+                { new StringContent(evaluation.Scope.ToString()), "scope" },
+                { new StringContent(evaluation.Provider.ToString()), "provider" },
+                { new StringContent(evaluation.Name), "name" },
+                { new StringContent(evaluation.Phone), "phone" },
+                { new StringContent(evaluation.Password), "password" },
 
                 // populate the file stream
-                { new StreamContent(evaluation.Content), "File", evaluation.FileName },
+                { new StreamContent(evaluation.Content), "file", evaluation.FileName },
             };
 
             // Add description if provided

--- a/src/Falu/Events/WebhookEvent.cs
+++ b/src/Falu/Events/WebhookEvent.cs
@@ -16,7 +16,7 @@ namespace Falu.Events
         public DateTimeOffset Created { get; set; }
 
         /// <summary>
-        /// Type of event (e.g. payment.updated, balance.updated, etc.).
+        /// Type of event (e.g. payment.updated, payment_balances.updated, etc.).
         /// Possible values are available in <see cref="Webhooks.EventTypes"/>.
         /// </summary>
         public string? Type { get; set; }

--- a/src/Falu/Events/WebhookEventData.cs
+++ b/src/Falu/Events/WebhookEventData.cs
@@ -7,7 +7,7 @@
     {
         /// <summary>
         /// Object containing the API resource relevant to the event.
-        /// For example, a <c>balance.updated</c> event will have a full balance object.
+        /// For example, a <c>payment_balances.updated</c> event will have a full balance object.
         /// </summary>
         public TObject? Object { get; set; }
 

--- a/src/Falu/Extensions/EnumExtensions.cs
+++ b/src/Falu/Extensions/EnumExtensions.cs
@@ -5,19 +5,14 @@ namespace System.Collections.Generic
 {
     internal static class EnumExtensions
     {
-        public static string? GetEnumMemberAttrValue<T>(this T enumVal) where T : Enum
+        public static string GetEnumMemberAttrValueOrDefault<T>(this T enumVal) where T : Enum
         {
             var memInfo = typeof(T).GetMember(enumVal.ToString());
             var attr = memInfo.FirstOrDefault()?.GetCustomAttributes(false)
                               .OfType<EnumMemberAttribute>()
                               .FirstOrDefault();
 
-            return attr?.Value;
-        }
-
-        public static string GetEnumMemberAttrValueOrDefault<T>(this T enumVal) where T : Enum
-        {
-            return enumVal.GetEnumMemberAttrValue() ?? enumVal.ToString().ToLowerInvariant();
+            return attr?.Value ?? enumVal.ToString().ToLowerInvariant();
         }
     }
 }

--- a/src/Falu/Extensions/EnumExtensions.cs
+++ b/src/Falu/Extensions/EnumExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+using System.Runtime.Serialization;
+
+namespace System.Collections.Generic
+{
+    internal static class EnumExtensions
+    {
+        public static string? GetEnumMemberAttrValue<T>(this T enumVal) where T : Enum
+        {
+            var memInfo = typeof(T).GetMember(enumVal.ToString());
+            var attr = memInfo.FirstOrDefault()?.GetCustomAttributes(false)
+                              .OfType<EnumMemberAttribute>()
+                              .FirstOrDefault();
+
+            return attr?.Value;
+        }
+
+        public static string GetEnumMemberAttrValueOrDefault<T>(this T enumVal) where T : Enum
+        {
+            return enumVal.GetEnumMemberAttrValue() ?? enumVal.ToString().ToLowerInvariant();
+        }
+    }
+}

--- a/src/Falu/Falu.csproj
+++ b/src/Falu/Falu.csproj
@@ -2,12 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Deterministic>true</Deterministic>
     <!--<IsPackable>true</IsPackable>-->
     <Description>The official client library for Falu. (https://falu.io)</Description>
-    <Company>Tingle Software Limited</Company>
-    <Authors>Tingle Software Limited</Authors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,28 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Tingle.Extensions.JsonPatch" Version="3.4.2" />
-  </ItemGroup>
-
-  <PropertyGroup>
-    <!--  Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-
-    <!-- Embed source files that are not tracked by the source control manager in the PDB -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-
-    <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <VersionPrefix Condition="'$(GITVERSION_NUGETVERSION)' != ''">$(GITVERSION_NUGETVERSION)</VersionPrefix>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Falu/Falu.csproj
+++ b/src/Falu/Falu.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <!--<IsPackable>true</IsPackable>-->
     <Description>The official client library for Falu. (https://falu.io)</Description>
   </PropertyGroup>
 

--- a/src/Falu/MessageStreams/MessageStreamPatchModel.cs
+++ b/src/Falu/MessageStreams/MessageStreamPatchModel.cs
@@ -20,6 +20,7 @@ namespace Falu.MessageStreams
         public Dictionary<string, string>? Metadata { get; set; }
 
         /// <inheritdoc/>
+        [System.Obsolete(MessageStrings.TagsDeprecated)]
         public List<string>? Tags { get; set; }
     }
 }

--- a/src/Falu/MessageStrings.cs
+++ b/src/Falu/MessageStrings.cs
@@ -1,0 +1,7 @@
+﻿namespace Falu
+{
+    internal class MessageStrings
+    {
+        public const string TagsDeprecated = "Tags have been deprecated and scheduled to be removed in a future API update. Migrate to using Metadata.";
+    }
+}

--- a/src/Falu/MessageTemplates/MessageTemplatePatchModel.cs
+++ b/src/Falu/MessageTemplates/MessageTemplatePatchModel.cs
@@ -28,6 +28,7 @@ namespace Falu.MessageTemplates
         public Dictionary<string, string>? Metadata { get; set; }
 
         /// <inheritdoc/>
+        [System.Obsolete(MessageStrings.TagsDeprecated)]
         public List<string>? Tags { get; set; }
     }
 }

--- a/src/Falu/Messages/MessagePatchModel.cs
+++ b/src/Falu/Messages/MessagePatchModel.cs
@@ -12,6 +12,7 @@ namespace Falu.Messages
         public Dictionary<string, string>? Metadata { get; set; }
 
         /// <inheritdoc/>
+        [System.Obsolete(MessageStrings.TagsDeprecated)]
         public List<string>? Tags { get; set; }
     }
 }

--- a/src/Falu/PaymentAuthorizations/PaymentAuthorization.cs
+++ b/src/Falu/PaymentAuthorizations/PaymentAuthorization.cs
@@ -48,6 +48,11 @@ namespace Falu.PaymentAuthorizations
         /// </summary>
         public PaymentMpesaDetails? Mpesa { get; set; }
 
+        /// <summary>
+        /// Identifier of the payment created after the authorization is approved and closed.
+        /// </summary>
+        public string? PaymentId { get; set; }
+
         /// <inheritdoc/>
         public string? WorkspaceId { get; set; }
 

--- a/src/Falu/PaymentAuthorizations/PaymentAuthorizationPatchModel.cs
+++ b/src/Falu/PaymentAuthorizations/PaymentAuthorizationPatchModel.cs
@@ -12,6 +12,7 @@ namespace Falu.PaymentAuthorizations
         public Dictionary<string, string>? Metadata { get; set; }
 
         /// <inheritdoc/>
+        [System.Obsolete(MessageStrings.TagsDeprecated)]
         public List<string>? Tags { get; set; }
     }
 }

--- a/src/Falu/PaymentReversals/PaymentReversalFailureReason.cs
+++ b/src/Falu/PaymentReversals/PaymentReversalFailureReason.cs
@@ -19,6 +19,10 @@ namespace Falu.PaymentReversals
         AuthenticationError,
 
         ///
+        [EnumMember(Value = "amount_out_of_bound")]
+        AmountOutOfBound,
+
+        ///
         Timeout,
 
         ///

--- a/src/Falu/PaymentReversals/PaymentReversalPatchModel.cs
+++ b/src/Falu/PaymentReversals/PaymentReversalPatchModel.cs
@@ -15,6 +15,7 @@ namespace Falu.PaymentReversals
         public Dictionary<string, string>? Metadata { get; set; }
 
         /// <inheritdoc/>
+        [System.Obsolete(MessageStrings.TagsDeprecated)]
         public List<string>? Tags { get; set; }
     }
 }

--- a/src/Falu/Payments/Payment.cs
+++ b/src/Falu/Payments/Payment.cs
@@ -36,6 +36,11 @@ namespace Falu.Payments
         public DateTimeOffset? Succeeded { get; set; }
 
         /// <summary>
+        /// Identifier of the authorization, if the payment passed through a flow requiring authorization.
+        /// </summary>
+        public string? AuthorizationId { get; set; }
+
+        /// <summary>
         /// The type of the Payment.
         /// An additional property is populated on the Payment with a name matching this value.
         /// It contains additional information specific to the Payment type.

--- a/src/Falu/Payments/PaymentFailureReason.cs
+++ b/src/Falu/Payments/PaymentFailureReason.cs
@@ -19,6 +19,10 @@ namespace Falu.Payments
         AuthenticationError,
 
         ///
+        [EnumMember(Value = "amount_out_of_bound")]
+        AmountOutOfBound,
+
+        ///
         Timeout,
 
         ///

--- a/src/Falu/Payments/PaymentPatchModel.cs
+++ b/src/Falu/Payments/PaymentPatchModel.cs
@@ -15,6 +15,7 @@ namespace Falu.Payments
         public Dictionary<string, string>? Metadata { get; set; }
 
         /// <inheritdoc/>
+        [System.Obsolete(MessageStrings.TagsDeprecated)]
         public List<string>? Tags { get; set; }
     }
 }

--- a/src/Falu/TransferReversals/TransferReversalFailureReason.cs
+++ b/src/Falu/TransferReversals/TransferReversalFailureReason.cs
@@ -19,6 +19,10 @@ namespace Falu.TransferReversals
         AuthenticationError,
 
         ///
+        [EnumMember(Value = "amount_out_of_bound")]
+        AmountOutOfBound,
+
+        ///
         Timeout,
 
         ///

--- a/src/Falu/TransferReversals/TransferReversalPatchModel.cs
+++ b/src/Falu/TransferReversals/TransferReversalPatchModel.cs
@@ -15,6 +15,7 @@ namespace Falu.TransferReversals
         public Dictionary<string, string>? Metadata { get; set; }
 
         /// <inheritdoc/>
+        [System.Obsolete(MessageStrings.TagsDeprecated)]
         public List<string>? Tags { get; set; }
     }
 }

--- a/src/Falu/Transfers/TransferFailureReason.cs
+++ b/src/Falu/Transfers/TransferFailureReason.cs
@@ -19,6 +19,10 @@ namespace Falu.Transfers
         AuthenticationError,
 
         ///
+        [EnumMember(Value = "amount_out_of_bound")]
+        AmountOutOfBound,
+
+        ///
         Timeout,
 
         ///

--- a/src/Falu/Transfers/TransferPatchModel.cs
+++ b/src/Falu/Transfers/TransferPatchModel.cs
@@ -15,6 +15,7 @@ namespace Falu.Transfers
         public Dictionary<string, string>? Metadata { get; set; }
 
         /// <inheritdoc/>
+        [System.Obsolete(MessageStrings.TagsDeprecated)]
         public List<string>? Tags { get; set; }
     }
 }

--- a/src/Falu/Webhooks/EventTypes.cs
+++ b/src/Falu/Webhooks/EventTypes.cs
@@ -25,9 +25,9 @@
         #region Payments
 
         /// <summary>
-        /// Occurs whenever the balance has been updated.
+        /// Occurs whenever a payment balances are updated.
         /// </summary>
-        public const string BalanceUpdated = "balance.updated";
+        public const string PaymentBalancesUpdated = "payment_balances.updated";
 
         /// <summary>
         /// Occurs whenever a payment is updated.

--- a/src/Falu/Webhooks/WebhookEndpointPatchModel.cs
+++ b/src/Falu/Webhooks/WebhookEndpointPatchModel.cs
@@ -36,6 +36,7 @@ namespace Falu.Webhooks
         public Dictionary<string, string>? Metadata { get; set; }
 
         /// <inheritdoc/>
+        [System.Obsolete(MessageStrings.TagsDeprecated)]
         public List<string>? Tags { get; set; }
     }
 }


### PR DESCRIPTION
- Make use of explicit names when working with `MultiPartFormDataContent`
- Update event for balance.
- Added `AmountOfBound` to all `*FailureReason` enums.
- `Phone` and `Password` are optional when creating an evaluation.
- Deprecated `Tags` in favour of `Metadata`.