### PR TITLE
Support usage of IConfiguration

### DIFF
--- a/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
+++ b/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
@@ -75,10 +75,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configure">An <see cref="Action{FaluClientOptions}"/> to configure the client options.</param>
         /// <param name="configureBuilder">An <see cref="Action{IHttpClientBuilder}"/> to configure the HTTP client builder.</param>
         /// <returns></returns>
-        private static IServiceCollection AddFalu(this IServiceCollection services,
-                                                  IConfiguration? configuration = null,
-                                                  Action<FaluClientOptions>? configure = null,
-                                                  Action<IHttpClientBuilder>? configureBuilder = null)
+        public static IServiceCollection AddFalu(this IServiceCollection services,
+                                                 IConfiguration? configuration = null,
+                                                 Action<FaluClientOptions>? configure = null,
+                                                 Action<IHttpClientBuilder>? configureBuilder = null)
         {
             if (configuration is not null)
             {

--- a/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
+++ b/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
@@ -1,12 +1,12 @@
 ﻿using Falu;
 using Falu.Infrastructure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Polly;
 using Polly.Contrib.WaitAndRetry;
 using Polly.Extensions.Http;
 using System;
 using System.Net;
-using System.Net.Http.Headers;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -18,15 +18,78 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Add client for Falu API
         /// </summary>
+        /// <param name="services">the collection to be added to</param>
+        /// <param name="apiKey"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddFalu(this IServiceCollection services, string apiKey)
+        {
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                throw new ArgumentNullException(nameof(apiKey));
+            }
+
+            return services.AddFalu(o => o.ApiKey = apiKey);
+        }
+
+        /// <summary>
+        /// Add client for Falu API
+        /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/> to be added to.</param>
+        /// <param name="configure">An <see cref="Action{FaluClientOptions}"/> to configure the client options.</param>
+        /// <returns></returns>
+        public static IServiceCollection AddFalu(this IServiceCollection services, Action<FaluClientOptions> configure)
+        {
+            if (configure is null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            return services.AddFalu(configuration: null, configure: configure, configureBuilder: null);
+        }
+
+        /// <summary>
+        /// Add client for Falu API
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to be added to.</param>
+        /// <param name="configuration">
+        /// An <see cref="IConfiguration"/> containing the values of <see cref="FaluClientOptions"/> at its root.
+        /// </param>
+        /// <returns></returns>
+        public static IServiceCollection AddFalu(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (configuration is null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            return services.AddFalu(configuration: configuration, configure: null, configureBuilder: null);
+        }
+
+        /// <summary>
+        /// Add client for Falu API
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to be added to.</param>
+        /// <param name="configuration">
+        /// An <see cref="IConfiguration"/> containing the values of <see cref="FaluClientOptions"/> at its root.
+        /// </param>
         /// <param name="configure">An <see cref="Action{FaluClientOptions}"/> to configure the client options.</param>
         /// <param name="configureBuilder">An <see cref="Action{IHttpClientBuilder}"/> to configure the HTTP client builder.</param>
         /// <returns></returns>
-        public static IServiceCollection AddFalu(this IServiceCollection services,
-                                                 Action<FaluClientOptions>? configure = null,
-                                                 Action<IHttpClientBuilder>? configureBuilder = null)
+        private static IServiceCollection AddFalu(this IServiceCollection services,
+                                                  IConfiguration? configuration = null,
+                                                  Action<FaluClientOptions>? configure = null,
+                                                  Action<IHttpClientBuilder>? configureBuilder = null)
         {
-            if (configure != null) services.Configure(configure);
+            if (configuration is not null)
+            {
+                services.Configure<FaluClientOptions>(configuration);
+            }
+
+            if (configure != null)
+            {
+                services.Configure(configure);
+            }
+
             services.PostConfigure<FaluClientOptions>(o =>
             {
                 if (string.IsNullOrWhiteSpace(o.ApiKey))
@@ -82,19 +145,6 @@ namespace Microsoft.Extensions.DependencyInjection
             configureBuilder?.Invoke(builder);
 
             return services;
-        }
-
-        /// <summary>
-        /// Add client for Falu API
-        /// </summary>
-        /// <param name="services">the collection to be added to</param>
-        /// <param name="apiKey"></param>
-        /// <returns></returns>
-        public static IServiceCollection AddFalu(this IServiceCollection services, string apiKey)
-        {
-            if (string.IsNullOrWhiteSpace(apiKey))
-                throw new ArgumentNullException(nameof(apiKey));
-            return services.AddFalu(o => o.ApiKey = apiKey);
         }
     }
 }

--- a/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
+++ b/src/FaluSdk/Extensions/IServiceCollectionExtensions.cs
@@ -90,22 +90,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.Configure(configure);
             }
 
-            services.PostConfigure<FaluClientOptions>(o =>
-            {
-                if (string.IsNullOrWhiteSpace(o.ApiKey))
-                {
-                    var message = "Your API key is invalid, as it is an empty string. You can "
-                                + "double-check your API key from the Falu Dashboard. See "
-                                + "https://docs.falu.io/api/authentication for details or contact support "
-                                + "at https://falu.com/support/email if you have any questions.";
-                    throw new FaluException(message);
-                }
-
-                if (o.Retries < 0)
-                {
-                    throw new FaluException("Retries cannot be negative.");
-                }
-            });
+            // register post configuration for validation purposes
+            services.AddSingleton<IPostConfigureOptions<FaluClientOptions>, FaluClientOptionsPostConfigureOptions>();
 
             // get the version from the assembly
             var productVersion = typeof(FaluClient).Assembly.GetName().Version.ToString(3);

--- a/src/FaluSdk/FaluClientOptionsPostConfigureOptions.cs
+++ b/src/FaluSdk/FaluClientOptionsPostConfigureOptions.cs
@@ -1,0 +1,25 @@
+﻿using Falu.Infrastructure;
+using Microsoft.Extensions.Options;
+
+namespace Falu
+{
+    internal class FaluClientOptionsPostConfigureOptions : IPostConfigureOptions<FaluClientOptions>
+    {
+        public void PostConfigure(string name, FaluClientOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(options.ApiKey))
+            {
+                var message = "Your API key is invalid, as it is an empty string. You can "
+                            + "double-check your API key from the Falu Dashboard. See "
+                            + "https://docs.falu.io/api/authentication for details or contact support "
+                            + "at https://falu.com/support/email if you have any questions.";
+                throw new FaluException(message);
+            }
+
+            if (options.Retries < 0)
+            {
+                throw new FaluException("Retries cannot be negative.");
+            }
+        }
+    }
+}

--- a/src/FaluSdk/FaluSdk.csproj
+++ b/src/FaluSdk/FaluSdk.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.0" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Tingle.Extensions.JsonPatch" Version="3.4.2" />

--- a/tests/FaluSdk.Tests/FaluSdk.Tests.csproj
+++ b/tests/FaluSdk.Tests/FaluSdk.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/FaluSdk.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/FaluSdk.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,6 +1,8 @@
 using Falu.Infrastructure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -68,6 +70,28 @@ namespace Falu.Tests
             // Arrange
             var services = new ServiceCollection()
                 .AddFalu(options => options.ApiKey = "FAKE_APIKEY")
+                .BuildServiceProvider();
+
+            // Act
+            var client = services.GetService<FaluClient>();
+
+            // Assert
+            Assert.NotNull(client);
+        }
+
+        [Fact]
+        public void TestAddFaluCanResolveFaluClientFromConfiguration()
+        {
+            // Arrange
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Falu:ApiKey"] = "FAKE_APIKEY",
+                    ["Falu:Retries"] = "0",
+                })
+                .Build();
+            var services = new ServiceCollection()
+                .AddFalu(configuration.GetSection("Falu"))
                 .BuildServiceProvider();
 
             // Act


### PR DESCRIPTION
Added support for pulling values for `FaluClientOptions` such as `ApiKey` and `Retries` from instances of `IConfiguration`